### PR TITLE
Fixed invalid conversion from void to int errors

### DIFF
--- a/src/mysql_bindings_connection.cc
+++ b/src/mysql_bindings_connection.cc
@@ -451,7 +451,7 @@ int MysqlConnection::EIO_After_Connect(eio_req *req) {
     return 0;
 }
 
-void MysqlConnection::EIO_Connect(eio_req *req) {
+int MysqlConnection::EIO_Connect(eio_req *req) {
     struct connect_request *conn_req = (struct connect_request *)(req->data);
 
     req->result = conn_req->conn->Connect(
@@ -472,6 +472,7 @@ void MysqlConnection::EIO_Connect(eio_req *req) {
     delete conn_req->user;
     delete conn_req->password;
     delete conn_req->socket;
+    return req->result;
 }
 #endif
 
@@ -1087,14 +1088,14 @@ int MysqlConnection::EIO_After_Query(eio_req *req) {
     return 0;
 }
 
-void MysqlConnection::EIO_Query(eio_req *req) {
+int MysqlConnection::EIO_Query(eio_req *req) {
     struct query_request *query_req = (struct query_request *)(req->data);
 
     MysqlConnection *conn = query_req->conn;
 
     if (!conn->_conn) {
         req->result = 1;
-        return;
+        return req->result;
     }
 
     MYSQLCONN_DISABLE_MQ;
@@ -1133,6 +1134,7 @@ void MysqlConnection::EIO_Query(eio_req *req) {
         }
     }
     pthread_mutex_unlock(&conn->query_lock);
+    return req->result;
 }
 #endif
 

--- a/src/mysql_bindings_connection.h
+++ b/src/mysql_bindings_connection.h
@@ -169,7 +169,7 @@ class MysqlConnection : public node::ObjectWrap {
         const char *error;
     };
     static int EIO_After_Connect(eio_req *req);
-    static void EIO_Connect(eio_req *req);
+    static int EIO_Connect(eio_req *req);
 #endif
     static Handle<Value> Connect(const Arguments& args);
 
@@ -232,7 +232,7 @@ class MysqlConnection : public node::ObjectWrap {
         const char *error;
     };
     static int EIO_After_Query(eio_req *req);
-    static void EIO_Query(eio_req *req);
+    static int EIO_Query(eio_req *req);
 #endif
     static Handle<Value> Query(const Arguments& args);
 

--- a/src/mysql_bindings_result.cc
+++ b/src/mysql_bindings_result.cc
@@ -420,7 +420,7 @@ int MysqlResult::EIO_After_FetchAll(eio_req *req) {
     return 0;
 }
 
-void MysqlResult::EIO_FetchAll(eio_req *req) {
+int MysqlResult::EIO_FetchAll(eio_req *req) {
     struct fetchAll_request *fetchAll_req =
         reinterpret_cast<struct fetchAll_request *>(req->data);
     MysqlResult *res = fetchAll_req->res;
@@ -431,6 +431,7 @@ void MysqlResult::EIO_FetchAll(eio_req *req) {
     fetchAll_req->num_fields = mysql_num_fields(res->_res);
 
     req->result = 0;
+    return req->result;
 }
 #endif
 

--- a/src/mysql_bindings_result.h
+++ b/src/mysql_bindings_result.h
@@ -100,7 +100,7 @@ class MysqlResult : public node::ObjectWrap {
         bool results_structured;
     };
     static int EIO_After_FetchAll(eio_req *req);
-    static void EIO_FetchAll(eio_req *req);
+    static int EIO_FetchAll(eio_req *req);
 #endif
     static Handle<Value> FetchAll(const Arguments& args);
 


### PR DESCRIPTION
Changed several methods to return  int instead of void to fix the following errors
(compiled on Ubuntu -  g++ (Ubuntu 4.4.3-4ubuntu5) 4.4.3):

```
../src/mysql_bindings_connection.cc: In static member function ‘static v8::Handle<v8::Value> MysqlConnection::Connect(const v8::Arguments&)’:
../src/mysql_bindings_connection.cc:522: error: invalid conversion from ‘void (*)(eio_req*)’ to ‘int (*)(eio_req*)’
../src/mysql_bindings_connection.cc:522: error:   initializing argument 1 of ‘eio_req* eio_custom(int (*)(eio_req*), int, int (*)(eio_req*), void*)’
../src/mysql_bindings_connection.cc: In static member function ‘static v8::Handle<v8::Value> MysqlConnection::Query(const v8::Arguments&)’:
../src/mysql_bindings_connection.cc:1177: error: invalid conversion from ‘void (*)(eio_req*)’ to ‘int (*)(eio_req*)’
../src/mysql_bindings_connection.cc:1177: error:   initializing argument 1 of ‘eio_req* eio_custom(int (*)(eio_req*), int, int (*)(eio_req*), void*)’
../src/mysql_bindings_result.cc: In static member function ‘static v8::Handle<v8::Value> MysqlResult::FetchAll(const v8::Arguments&)’:
../src/mysql_bindings_result.cc:494: error: invalid conversion from ‘void (*)(eio_req*)’ to ‘int (*)(eio_req*)’
../src/mysql_bindings_result.cc:494: error:   initializing argument 1 of ‘eio_req* eio_custom(int (*)(eio_req*), int, int (*)(eio_req*), void*)’
```
