### PR TITLE
Fix segmentation fault when mysql returns some error message like "table is crashed"

### DIFF
--- a/src/mysql_bindings_connection.cc
+++ b/src/mysql_bindings_connection.cc
@@ -1114,11 +1114,12 @@ void MysqlConnection::EIO_Query(eio_req *req) {
 
     pthread_mutex_lock(&conn->query_lock);
     int r = mysql_query(conn->_conn, query_req->query);
-    if (r != 0) {
+    int errno = mysql_errno(conn->_conn);
+    if (r != 0 || errno != 0) {
         // Query error
         req->result = 1;
 
-        query_req->errno = mysql_errno(conn->_conn);
+        query_req->errno = errno;
         query_req->error = mysql_error(conn->_conn);
     } else {
         req->result = 0;
@@ -1142,6 +1143,8 @@ void MysqlConnection::EIO_Query(eio_req *req) {
             } else {
                 // Result store error
                 req->result = 1;
+                query_req->errno = errno;
+                query_req->error = mysql_error(conn->_conn);
             }
         }
     }


### PR DESCRIPTION
Bug is in file "mysql_bindings_connection.cc"

When mysql returns error like "ERROR 1194 (HY000): Table 'xxx' is marked as crashed and should be repaired", this lib will cause segmentation fault. It is because when this kind of error occurs, "mysql_query()" still returns 0(line 1116). but "mysql_field_count()" doesn't return 0(line 1128). Finally it goes into "Result store error" part in your codes(about line 1143). You set "req->result" to number 1, but not get error number and error message again. Then in function "EIO_After_Query()"(line 1038), "req->result" is 1 but "query_req->error" is null(line 1048). Segmentation fault occurs when "strlen(query_req->error)" is executed(line 1048). 

I have fixed this bug. The return value "r" from function "mysql_query()"(line 1117) is not enough to judge whether mysql returns error message. This lib should also check error number from function "mysql_errno()". In addition, I added functions to get error number and error message when req_result is set to 1(line 1144).

Fixed codes is provided. You can see the details from my codes:)
