### PR TITLE
Make LOAD DATA LOCAL work for MysqlConnectionQueued

### DIFF
--- a/lib/mysql-libmysqlclient.js
+++ b/lib/mysql-libmysqlclient.js
@@ -300,15 +300,24 @@ MysqlConnectionQueued.prototype.connect = function connect() {
 };
 
 /**
- * MysqlConnectionQueued#query(query[, callback])
+ * MysqlConnectionQueued#query(query[, queryData][, callback])
  *
  * Performs a query on the database
  *
  * Uses mysql_real_query()
  **/
-MysqlConnectionQueued.prototype.query = function query(query, callback) {
-  this._queue.push(['query', [query], callback]);
-
+MysqlConnectionQueued.prototype.query = function query(query) {
+  var callback,
+    queryArgs;
+  if (arguments[arguments.length - 1] instanceof Function) {
+    var callback = arguments[arguments.length - 1];
+    queryArgs = [].slice.call(arguments, 0, -1);
+  } else {
+    callback = undefined;
+    //transform arguments into normal Array
+    queryArgs = [].slice.call(arguments, 0);
+  }
+  this._queue.push(['query', queryArgs, callback]);
   this._processQueue();
 };
 
@@ -449,14 +458,14 @@ MysqlConnectionHighlevel.prototype.setQueryTypeSync = function setQueryTypeSync(
 };
 
 /**
- * MysqlConnectionHighlevel#query(query[, callback])
+ * MysqlConnectionHighlevel#query(query[, queryData][, callback]) 
  *
  * Performs a query on the database
  *
  * Uses mysql_real_query() or mysql_send_query()
  * depends on this._queryType
  **/
-MysqlConnectionHighlevel.prototype.query = function query(query, callback) {
+MysqlConnectionHighlevel.prototype.query = function query(query, queryData, callback) {
   switch (this._queryType) {
     case 'query':
       MysqlConnectionQueued.prototype.query.apply(this, arguments);


### PR DESCRIPTION
MysqlConnectionQueued and MysqlConnectionHighlevel have never worked for queries like
LOAD DATA INFILE (loading data from csv/tsv formatted string from mysql client's memory).
The only way to send such query was using of c++ binding directly. 
Fix this.
