### PR TITLE
Add missing return statements

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 
   "scripts" : { "test" : "make test", "doc" : "make doc" },
 
-  "dependencies" : { "nan" : "~2.2.1" },
+  "dependencies" : { "nan" : "~2.4.0" },
 
   "devDependencies" :
   { "nodeunit" : "~0.8.8"

--- a/src/mysql_bindings_connection.cc
+++ b/src/mysql_bindings_connection.cc
@@ -222,7 +222,7 @@ NAN_METHOD(MysqlConnection::New) {
     MysqlConnection *conn = new MysqlConnection();
     conn->Wrap(info.Holder());
 
-    info.GetReturnValue().Set(info.This());
+    return info.GetReturnValue().Set(info.This());
 }
 
 /** read-only
@@ -237,7 +237,7 @@ NAN_GETTER(MysqlConnection::ConnectErrnoGetter) {
 
     MysqlConnection *conn = OBJUNWRAP<MysqlConnection>(info.Holder());
 
-    info.GetReturnValue().Set(v8::Integer::NewFromUnsigned(isolate,conn->connect_errno));
+    return info.GetReturnValue().Set(v8::Integer::NewFromUnsigned(isolate,conn->connect_errno));
 }
 
 /** read-only
@@ -252,9 +252,9 @@ NAN_GETTER(MysqlConnection::ConnectErrorGetter) {
 
     MysqlConnection *conn = OBJUNWRAP<MysqlConnection>(info.Holder());
     if(conn->connect_error) 
-        info.GetReturnValue().Set(v8::String::NewFromUtf8(isolate,conn->connect_error)) ; 
-    else info.GetReturnValue().Set(v8::String::NewFromUtf8(isolate,"")) ; 
-    //info.GetReturnValue().Set(Nan::New<String>(conn->connect_error ? conn->connect_error : ""));
+        return info.GetReturnValue().Set(v8::String::NewFromUtf8(isolate,conn->connect_error)) ; 
+    else return info.GetReturnValue().Set(v8::String::NewFromUtf8(isolate,"")) ; 
+    //return info.GetReturnValue().Set(Nan::New<String>(conn->connect_error ? conn->connect_error : ""));
 }
 
 /**
@@ -273,10 +273,10 @@ NAN_METHOD(MysqlConnection::AffectedRowsSync) {
     my_ulonglong affected_rows = mysql_affected_rows(conn->_conn);
 
     if (affected_rows == ((my_ulonglong)-1)) {
-        info.GetReturnValue().Set(v8::Integer::NewFromUnsigned(isolate,-1));
+        return info.GetReturnValue().Set(v8::Integer::NewFromUnsigned(isolate,-1));
     }
 
-    info.GetReturnValue().Set(v8::Integer::NewFromUnsigned(isolate,affected_rows));
+    return info.GetReturnValue().Set(v8::Integer::NewFromUnsigned(isolate,affected_rows));
 }
 
 /**
@@ -295,10 +295,10 @@ NAN_METHOD(MysqlConnection::AutoCommitSync) {
     REQ_BOOL_ARG(0, autocomit)
 
     if (mysql_autocommit(conn->_conn, autocomit)) {
-        info.GetReturnValue().Set(False());
+        return info.GetReturnValue().Set(False());
     }
 
-    info.GetReturnValue().Set(True());
+    return info.GetReturnValue().Set(True());
 }
 
 /**
@@ -336,10 +336,10 @@ NAN_METHOD(MysqlConnection::ChangeUserSync) {
                                info[2]->IsString() ? *dbname : NULL);
 
     if (r) {
-        info.GetReturnValue().Set(False());
+        return info.GetReturnValue().Set(False());
     }
 
-    info.GetReturnValue().Set(True());
+    return info.GetReturnValue().Set(True());
 }
 
 /**
@@ -355,10 +355,10 @@ NAN_METHOD(MysqlConnection::CommitSync) {
     MYSQLCONN_MUSTBE_CONNECTED;
 
     if (mysql_commit(conn->_conn)) {
-        info.GetReturnValue().Set(False());
+        return info.GetReturnValue().Set(False());
     }
 
-    info.GetReturnValue().Set(True());
+    return info.GetReturnValue().Set(True());
 }
 
 /*!
@@ -451,7 +451,7 @@ NAN_METHOD(MysqlConnection::Connect) {
             node::FatalException(isolate,try_catch);
         }
 
-        info.GetReturnValue().Set(Nan::Undefined());
+        return info.GetReturnValue().Set(Nan::Undefined());
     }
 
     connect_request *conn_req = new connect_request;
@@ -481,7 +481,7 @@ NAN_METHOD(MysqlConnection::Connect) {
     _req->data = conn_req; \
     uv_queue_work(uv_default_loop(), _req, EIO_Connect, (uv_after_work_cb)EIO_After_Connect);
 
-    info.GetReturnValue().Set(Nan::Undefined());
+    return info.GetReturnValue().Set(Nan::Undefined());
 }
 
 /**
@@ -522,10 +522,10 @@ NAN_METHOD(MysqlConnection::ConnectSync) {
     );
 
     if (!r) {
-        info.GetReturnValue().Set(False());
+        return info.GetReturnValue().Set(False());
     }
 
-    info.GetReturnValue().Set(True());
+    return info.GetReturnValue().Set(True());
 }
 
 /**
@@ -538,7 +538,7 @@ NAN_METHOD(MysqlConnection::ConnectedSync) {
 
     MysqlConnection *conn = OBJUNWRAP<MysqlConnection>(info.Holder());
 
-    info.GetReturnValue().Set(conn->connected ? True() : False());
+    return info.GetReturnValue().Set(conn->connected ? True() : False());
 }
 
 /**
@@ -555,7 +555,7 @@ NAN_METHOD(MysqlConnection::CloseSync) {
 
     conn->Close();
 
-    info.GetReturnValue().Set(Nan::Undefined());
+    return info.GetReturnValue().Set(Nan::Undefined());
 }
 
 /**
@@ -575,7 +575,7 @@ NAN_METHOD(MysqlConnection::DebugSync) {
 
     mysql_debug(*debug);
 
-    info.GetReturnValue().Set(Nan::Undefined());
+    return info.GetReturnValue().Set(Nan::Undefined());
 }
 
 /**
@@ -589,7 +589,7 @@ NAN_METHOD(MysqlConnection::DumpDebugInfoSync) {
 
     MYSQLCONN_MUSTBE_CONNECTED;
 
-    info.GetReturnValue().Set(mysql_dump_debug_info(conn->_conn) ? False() : True());
+    return info.GetReturnValue().Set(mysql_dump_debug_info(conn->_conn) ? False() : True());
 }
 
 /**
@@ -605,7 +605,7 @@ NAN_METHOD(MysqlConnection::ErrnoSync) {
 
     MYSQLCONN_MUSTBE_CONNECTED;
 
-    info.GetReturnValue().Set(Integer::NewFromUnsigned(isolate,mysql_errno(conn->_conn)));
+    return info.GetReturnValue().Set(Integer::NewFromUnsigned(isolate,mysql_errno(conn->_conn)));
 }
 
 /**
@@ -623,7 +623,7 @@ NAN_METHOD(MysqlConnection::ErrorSync) {
 
     const char *error = mysql_error(conn->_conn);
 
-    info.GetReturnValue().Set(v8::String::NewFromUtf8(isolate,error));
+    return info.GetReturnValue().Set(v8::String::NewFromUtf8(isolate,error));
 }
 
 /**
@@ -655,7 +655,7 @@ NAN_METHOD(MysqlConnection::EscapeSync) {
 
     delete[] result;
 
-    info.GetReturnValue().Set(js_result);
+    return info.GetReturnValue().Set(js_result);
 }
 
 /**
@@ -671,7 +671,7 @@ NAN_METHOD(MysqlConnection::FieldCountSync) {
 
     MYSQLCONN_MUSTBE_CONNECTED;
 
-    info.GetReturnValue().Set(
+    return info.GetReturnValue().Set(
                 Integer::NewFromUnsigned(isolate,
                     mysql_field_count(conn->_conn)));
 }
@@ -704,7 +704,7 @@ NAN_METHOD(MysqlConnection::GetCharsetSync) {
     js_result->Set(v8::String::NewFromUtf8(isolate,"state"), Integer::NewFromUnsigned(isolate,cs.state));
     js_result->Set(v8::String::NewFromUtf8(isolate,"comment"), v8::String::NewFromUtf8(isolate,cs.comment ? cs.comment : ""));
 
-    info.GetReturnValue().Set(js_result);
+    return info.GetReturnValue().Set(js_result);
 }
 
 /**
@@ -720,7 +720,7 @@ NAN_METHOD(MysqlConnection::GetCharsetNameSync) {
 
     MYSQLCONN_MUSTBE_CONNECTED;
 
-    info.GetReturnValue().Set(v8::String::NewFromUtf8(isolate,mysql_character_set_name(conn->_conn)));
+    return info.GetReturnValue().Set(v8::String::NewFromUtf8(isolate,mysql_character_set_name(conn->_conn)));
 }
 
 /**
@@ -739,7 +739,7 @@ NAN_METHOD(MysqlConnection::GetClientInfoSync) {
     js_result->Set(v8::String::NewFromUtf8(isolate,"client_version"),
                    Integer::NewFromUnsigned(isolate,mysql_get_client_version()));
 
-    info.GetReturnValue().Set(js_result);
+    return info.GetReturnValue().Set(js_result);
 }
 
 /**
@@ -771,7 +771,7 @@ NAN_METHOD(MysqlConnection::GetInfoSync) {
     js_result->Set(v8::String::NewFromUtf8(isolate,"proto_info"),
                    Integer::NewFromUnsigned(isolate,mysql_get_proto_info(conn->_conn)));
 
-    info.GetReturnValue().Set(js_result);
+    return info.GetReturnValue().Set(js_result);
 }
 
 /**
@@ -789,7 +789,7 @@ NAN_METHOD(MysqlConnection::GetInfoStringSync) {
 
     const char *infos = mysql_info(conn->_conn);
 
-    info.GetReturnValue().Set(v8::String::NewFromUtf8(isolate,infos ? infos : ""));
+    return info.GetReturnValue().Set(v8::String::NewFromUtf8(isolate,infos ? infos : ""));
 }
 
 /**
@@ -830,7 +830,7 @@ NAN_METHOD(MysqlConnection::GetWarningsSync) {
         }
     }
 
-    info.GetReturnValue().Set(js_result);
+    return info.GetReturnValue().Set(js_result);
 }
 
 /**
@@ -850,10 +850,10 @@ NAN_METHOD(MysqlConnection::InitSync) {
     conn->_conn = mysql_init(NULL);
 
     if (!conn->_conn) {
-        info.GetReturnValue().Set(False());
+        return info.GetReturnValue().Set(False());
     }
 
-    info.GetReturnValue().Set(True());
+    return info.GetReturnValue().Set(True());
 }
 
 /**
@@ -871,7 +871,7 @@ NAN_METHOD(MysqlConnection::InitStatementSync) {
     MYSQL_STMT *my_statement = mysql_stmt_init(conn->_conn);
 
     if (!my_statement) {
-        info.GetReturnValue().Set(False());
+        return info.GetReturnValue().Set(False());
     }
     
     Local<Object> local_js_result = MysqlStatement::NewInstance(my_statement);
@@ -879,7 +879,7 @@ NAN_METHOD(MysqlConnection::InitStatementSync) {
     persistent_js_result.Reset(local_js_result);
     //NanAssignPersistent(Object, persistent_js_result, local_js_result);
     v8::Local<v8::Object> ret = Nan::New(persistent_js_result) ;  
-    info.GetReturnValue().Set(ret);
+    return info.GetReturnValue().Set(ret);
 }
 
 /**
@@ -905,7 +905,7 @@ NAN_METHOD(MysqlConnection::LastInsertIdSync) {
         insert_id = mysql_insert_id(conn->_conn);
     }
 
-    info.GetReturnValue().Set(Integer::New(isolate,insert_id));
+    return info.GetReturnValue().Set(Integer::New(isolate,insert_id));
 }
 
 /**
@@ -921,10 +921,10 @@ NAN_METHOD(MysqlConnection::MultiMoreResultsSync) {
     MYSQLCONN_MUSTBE_CONNECTED;
 
     if (mysql_more_results(conn->_conn)) {
-        info.GetReturnValue().Set(True());
+        return info.GetReturnValue().Set(True());
     }
 
-    info.GetReturnValue().Set(False());
+    return info.GetReturnValue().Set(False());
 }
 
 /**
@@ -944,10 +944,10 @@ NAN_METHOD(MysqlConnection::MultiNextResultSync) {
     }
 
     if (!mysql_next_result(conn->_conn)) {
-        info.GetReturnValue().Set(True());
+        return info.GetReturnValue().Set(True());
     }
 
-    info.GetReturnValue().Set(False());
+    return info.GetReturnValue().Set(False());
 }
 
 /**
@@ -969,11 +969,11 @@ NAN_METHOD(MysqlConnection::MultiRealQuerySync) {
     unsigned int query_len = static_cast<unsigned int>(query.length());
     if (mysql_real_query(conn->_conn, *query, query_len) != 0) {
         MYSQLCONN_DISABLE_MQ;
-        info.GetReturnValue().Set(False());
+        return info.GetReturnValue().Set(False());
     }
     MYSQLCONN_DISABLE_MQ;
 
-    info.GetReturnValue().Set(True());
+    return info.GetReturnValue().Set(True());
 }
 
 /**
@@ -990,10 +990,10 @@ NAN_METHOD(MysqlConnection::PingSync) {
     MYSQLCONN_MUSTBE_CONNECTED;
 
     if (mysql_ping(conn->_conn)) {
-        info.GetReturnValue().Set(False());
+        return info.GetReturnValue().Set(False());
     }
 
-    info.GetReturnValue().Set(True());
+    return info.GetReturnValue().Set(True());
 }
 
 /*!
@@ -1189,7 +1189,7 @@ NAN_METHOD(MysqlConnection::Query) {
     _req->data = query_req;
     uv_queue_work(uv_default_loop(), _req, EIO_Query, (uv_after_work_cb)EIO_After_Query);
 
-    info.GetReturnValue().Set(Nan::Undefined());
+    return info.GetReturnValue().Set(Nan::Undefined());
 }
 
 /*!
@@ -1321,7 +1321,7 @@ NAN_METHOD(MysqlConnection::QuerySend) {
     uv_poll_init(uv_default_loop(), handle, conn->_conn->net.fd);
     uv_poll_start(handle, UV_READABLE, EV_After_QuerySend);
 
-    info.GetReturnValue().Set(Nan::Undefined());
+    return info.GetReturnValue().Set(Nan::Undefined());
 }
 
 
@@ -1361,22 +1361,22 @@ NAN_METHOD(MysqlConnection::QuerySync) {
     pthread_mutex_unlock(&conn->query_lock);
     if (r != 0) {
         // Query error
-        info.GetReturnValue().Set(False());
+        return info.GetReturnValue().Set(False());
     }
 
     if (!my_result) {
         if (field_count == 0) {
             // No result set - not a SELECT, SHOW, DESCRIBE or EXPLAIN
-            info.GetReturnValue().Set(True());
+            return info.GetReturnValue().Set(True());
         } else {
             // Error
-            info.GetReturnValue().Set(False());
+            return info.GetReturnValue().Set(False());
         }
     }
 
     Local<Object> local_js_result = MysqlResult::NewInstance(conn->_conn, my_result, field_count);
 
-    info.GetReturnValue().Set(local_js_result);
+    return info.GetReturnValue().Set(local_js_result);
 }
 
 /**
@@ -1392,10 +1392,10 @@ NAN_METHOD(MysqlConnection::RollbackSync) {
     MYSQLCONN_MUSTBE_CONNECTED;
 
     if (mysql_rollback(conn->_conn)) {
-        info.GetReturnValue().Set(False());
+        return info.GetReturnValue().Set(False());
     }
 
-    info.GetReturnValue().Set(True());
+    return info.GetReturnValue().Set(True());
 }
 
 /**
@@ -1432,10 +1432,10 @@ NAN_METHOD(MysqlConnection::RealConnectSync) {
                                info[6]->IsUint32() ? flags     : 0);
 
     if (!r) {
-        info.GetReturnValue().Set(False());
+        return info.GetReturnValue().Set(False());
     }
 
-    info.GetReturnValue().Set(True());
+    return info.GetReturnValue().Set(True());
 }
 
 /**
@@ -1462,10 +1462,10 @@ NAN_METHOD(MysqlConnection::RealQuerySync) {
     pthread_mutex_unlock(&conn->query_lock);
 
     if (r != 0) {
-        info.GetReturnValue().Set(False());
+        return info.GetReturnValue().Set(False());
     }
 
-    info.GetReturnValue().Set(True());
+    return info.GetReturnValue().Set(True());
 }
 
 /**
@@ -1484,10 +1484,10 @@ NAN_METHOD(MysqlConnection::SelectDbSync) {
     REQ_STR_ARG(0, dbname)
 
     if (mysql_select_db(conn->_conn, *dbname)) {
-        info.GetReturnValue().Set(False());
+        return info.GetReturnValue().Set(False());
     }
 
-    info.GetReturnValue().Set(True());
+    return info.GetReturnValue().Set(True());
 }
 
 /**
@@ -1506,10 +1506,10 @@ NAN_METHOD(MysqlConnection::SetCharsetSync) {
     REQ_STR_ARG(0, charset)
 
     if (mysql_set_character_set(conn->_conn, *charset)) {
-        info.GetReturnValue().Set(False());
+        return info.GetReturnValue().Set(False());
     }
 
-    info.GetReturnValue().Set(True());
+    return info.GetReturnValue().Set(True());
 }
 
 /**
@@ -1585,10 +1585,10 @@ NAN_METHOD(MysqlConnection::SetOptionSync) {
     }
 
     if (r) {
-        info.GetReturnValue().Set(False());
+        return info.GetReturnValue().Set(False());
     }
 
-    info.GetReturnValue().Set(True());
+    return info.GetReturnValue().Set(True());
 }
 
 /**
@@ -1629,7 +1629,7 @@ NAN_METHOD(MysqlConnection::SetSslSync) {
         cipher
     );
 
-    info.GetReturnValue().Set(Nan::Undefined());
+    return info.GetReturnValue().Set(Nan::Undefined());
 }
 
 /**
@@ -1645,7 +1645,7 @@ NAN_METHOD(MysqlConnection::SqlStateSync) {
 
     MYSQLCONN_MUSTBE_CONNECTED;
 
-    info.GetReturnValue().Set(v8::String::NewFromUtf8(isolate,mysql_sqlstate(conn->_conn)));
+    return info.GetReturnValue().Set(v8::String::NewFromUtf8(isolate,mysql_sqlstate(conn->_conn)));
 }
 
 /**
@@ -1663,7 +1663,7 @@ NAN_METHOD(MysqlConnection::StatSync) {
 
     const char *stat = mysql_stat(conn->_conn);
 
-    info.GetReturnValue().Set(v8::String::NewFromUtf8(isolate,stat ? stat : ""));
+    return info.GetReturnValue().Set(v8::String::NewFromUtf8(isolate,stat ? stat : ""));
 }
 
 /**
@@ -1678,13 +1678,13 @@ NAN_METHOD(MysqlConnection::StoreResultSync) {
 
     if (!mysql_field_count(conn->_conn)) {
         /* no result set - not a SELECT, SHOW, DESCRIBE or EXPLAIN, */
-        info.GetReturnValue().Set(True());
+        return info.GetReturnValue().Set(True());
     }
 
     MYSQL_RES *my_result = mysql_store_result(conn->_conn);
 
     if (!my_result) {
-        info.GetReturnValue().Set(False());
+        return info.GetReturnValue().Set(False());
     }
 
     Local<Object> local_js_result = MysqlResult::NewInstance(conn->_conn, my_result, mysql_field_count(conn->_conn));
@@ -1695,7 +1695,7 @@ NAN_METHOD(MysqlConnection::StoreResultSync) {
     
     //NanAssignPersistent(Object, persistent_js_result, local_js_result);
 
-    info.GetReturnValue().Set(ret);
+    return info.GetReturnValue().Set(ret);
 }
 
 /**
@@ -1713,7 +1713,7 @@ NAN_METHOD(MysqlConnection::ThreadIdSync) {
 
     uint64_t thread_id = mysql_thread_id(conn->_conn);
 
-    info.GetReturnValue().Set(Integer::New(isolate,thread_id));
+    return info.GetReturnValue().Set(Integer::New(isolate,thread_id));
 }
 
 /**
@@ -1725,9 +1725,9 @@ NAN_METHOD(MysqlConnection::ThreadSafeSync) {
     Nan::HandleScope scope;
 
     if (mysql_thread_safe()) {
-        info.GetReturnValue().Set(True());
+        return info.GetReturnValue().Set(True());
     } else {
-        info.GetReturnValue().Set(False());
+        return info.GetReturnValue().Set(False());
     }
 }
 
@@ -1743,20 +1743,20 @@ NAN_METHOD(MysqlConnection::UseResultSync) {
 
     if (!mysql_field_count(conn->_conn)) {
         /* no result set - not a SELECT, SHOW, DESCRIBE or EXPLAIN, */
-        info.GetReturnValue().Set(True());
+        return info.GetReturnValue().Set(True());
     }
 
     MYSQL_RES *my_result = mysql_use_result(conn->_conn);
 
     if (!my_result) {
-        info.GetReturnValue().Set(False());
+        return info.GetReturnValue().Set(False());
     }
 
     Local<Object> local_js_result = MysqlResult::NewInstance(conn->_conn, my_result, mysql_field_count(conn->_conn));
     Nan::Persistent<Object> persistent_js_result;
     persistent_js_result.Reset(local_js_result) ;  
     v8::Local<v8::Object> ret = Nan::New(persistent_js_result) ; 
-    info.GetReturnValue().Set(ret);
+    return info.GetReturnValue().Set(ret);
 }
 
 /**
@@ -1774,7 +1774,7 @@ NAN_METHOD(MysqlConnection::WarningCountSync) {
 
     uint32_t warning_count = mysql_warning_count(conn->_conn);
 
-    info.GetReturnValue().Set(Integer::NewFromUnsigned(isolate,warning_count));
+    return info.GetReturnValue().Set(Integer::NewFromUnsigned(isolate,warning_count));
 }
 int MysqlConnection::CustomLocalInfileInit(void ** ptr, const char * filename, void * userdata) {
   *ptr = userdata;

--- a/src/mysql_bindings_result.cc
+++ b/src/mysql_bindings_result.cc
@@ -300,7 +300,7 @@ NAN_METHOD(MysqlResult::New) {
     MysqlResult *my_res = new MysqlResult(connection, result, field_count);
     my_res->Wrap(info.Holder());
 
-    info.GetReturnValue().Set(info.Holder());
+    return info.GetReturnValue().Set(info.Holder());
 }
 
 /** read-only
@@ -317,9 +317,9 @@ NAN_GETTER(MysqlResult::FieldCountGetter) {
     MYSQLRES_MUSTBE_VALID;
 
     if (res->field_count > 0) {
-        info.GetReturnValue().Set(Integer::NewFromUnsigned(isolate,res->field_count));
+        return info.GetReturnValue().Set(Integer::NewFromUnsigned(isolate,res->field_count));
     } else {
-        info.GetReturnValue().Set(Nan::Undefined());
+        return info.GetReturnValue().Set(Nan::Undefined());
     }
 }
 
@@ -348,7 +348,7 @@ NAN_METHOD(MysqlResult::DataSeekSync) {
 
     mysql_data_seek(res->_res, offset);
 
-    info.GetReturnValue().Set(Nan::Undefined());
+    return info.GetReturnValue().Set(Nan::Undefined());
 }
 
 /*!
@@ -508,7 +508,7 @@ NAN_METHOD(MysqlResult::FetchAll) {
         argv[0] = V8EXC("fetchAllSync can handle only (options) or none arguments",isolate);
         //TODO(Sannis): Use NanCallback here
         node::MakeCallback(isolate, Nan::GetCurrentContext()->Global(), callback, argc, argv);
-        info.GetReturnValue().Set(Nan::Undefined());
+        return info.GetReturnValue().Set(Nan::Undefined());
     }
 
     if (fo.results_as_array && fo.results_nest_tables) {
@@ -533,7 +533,7 @@ NAN_METHOD(MysqlResult::FetchAll) {
     _req->data = fetchAll_req;
     uv_queue_work(uv_default_loop(), _req, EIO_FetchAll, (uv_after_work_cb)EIO_After_FetchAll);
 
-    info.GetReturnValue().Set(Nan::Undefined());
+    return info.GetReturnValue().Set(Nan::Undefined());
 }
 
 /**
@@ -603,7 +603,7 @@ NAN_METHOD(MysqlResult::FetchAllSync) {
 
         i++;
     }
-    info.GetReturnValue().Set(js_result);
+    return info.GetReturnValue().Set(js_result);
 }
 
 /**
@@ -626,13 +626,13 @@ NAN_METHOD(MysqlResult::FetchFieldSync) {
     field = mysql_fetch_field(res->_res);
 
     if (!field) {
-        info.GetReturnValue().Set(False());
+        return info.GetReturnValue().Set(False());
     }
 
     js_result = Object::New(isolate);
     AddFieldProperties(js_result, field);
 
-    info.GetReturnValue().Set(js_result);
+    return info.GetReturnValue().Set(js_result);
 }
 
 /**
@@ -658,13 +658,13 @@ NAN_METHOD(MysqlResult::FetchFieldDirectSync) { // NOLINT
     field = mysql_fetch_field_direct(res->_res, field_num);
 
     if (!field) {
-        info.GetReturnValue().Set(False());
+        return info.GetReturnValue().Set(False());
     }
 
     js_result = Object::New(isolate);
     AddFieldProperties(js_result, field);
 
-    info.GetReturnValue().Set(js_result);
+    return info.GetReturnValue().Set(js_result);
 }
 
 /**
@@ -696,7 +696,7 @@ NAN_METHOD(MysqlResult::FetchFieldsSync) {
         js_result->Set(Integer::NewFromUnsigned(isolate,i), js_result_obj);
     }
 
-    info.GetReturnValue().Set(js_result);
+    return info.GetReturnValue().Set(js_result);
 }
 
 /**
@@ -719,7 +719,7 @@ NAN_METHOD(MysqlResult::FetchLengthsSync) {
     Local<Array> js_result = Array::New(isolate);
 
     if (!lengths) {
-        info.GetReturnValue().Set(False());
+        return info.GetReturnValue().Set(False());
     }
 
     for (i = 0; i < num_fields; i++) {
@@ -727,7 +727,7 @@ NAN_METHOD(MysqlResult::FetchLengthsSync) {
                        Integer::NewFromUnsigned(isolate,lengths[i]));
     }
 
-    info.GetReturnValue().Set(js_result);
+    return info.GetReturnValue().Set(js_result);
 }
 
 /**
@@ -767,7 +767,7 @@ NAN_METHOD(MysqlResult::FetchRowSync) {
     MYSQL_ROW result_row = mysql_fetch_row(res->_res);
 
     if (!result_row) {
-        info.GetReturnValue().Set(False());
+        return info.GetReturnValue().Set(False());
     }
 
     unsigned long *field_lengths = mysql_fetch_lengths(res->_res);
@@ -794,7 +794,7 @@ NAN_METHOD(MysqlResult::FetchRowSync) {
         }
     }
 
-    info.GetReturnValue().Set(js_result_row);
+    return info.GetReturnValue().Set(js_result_row);
 }
 
 /**
@@ -818,7 +818,7 @@ NAN_METHOD(MysqlResult::FieldSeekSync) {
 
     mysql_field_seek(res->_res, field_num);
 
-    info.GetReturnValue().Set(Nan::Undefined());
+    return info.GetReturnValue().Set(Nan::Undefined());
 }
 
 /**
@@ -834,7 +834,7 @@ NAN_METHOD(MysqlResult::FieldTellSync) {
 
     MYSQLRES_MUSTBE_VALID;
 
-    info.GetReturnValue().Set(Integer::NewFromUnsigned(isolate,mysql_field_tell(res->_res)));
+    return info.GetReturnValue().Set(Integer::NewFromUnsigned(isolate,mysql_field_tell(res->_res)));
 }
 
 /**
@@ -851,7 +851,7 @@ NAN_METHOD(MysqlResult::FreeSync) {
 
     res->Free();
 
-    info.GetReturnValue().Set(Nan::Undefined());
+    return info.GetReturnValue().Set(Nan::Undefined());
 }
 
 /**
@@ -871,5 +871,5 @@ NAN_METHOD(MysqlResult::NumRowsSync) {
         return Nan::ThrowError("Function cannot be used with MYSQL_USE_RESULT");
     }
 
-    info.GetReturnValue().Set(Integer::New(isolate,mysql_num_rows(res->_res)));
+    return info.GetReturnValue().Set(Integer::New(isolate,mysql_num_rows(res->_res)));
 }

--- a/src/mysql_bindings_statement.cc
+++ b/src/mysql_bindings_statement.cc
@@ -113,7 +113,7 @@ NAN_METHOD(MysqlStatement::New) {
     MysqlStatement *binding_stmt = new MysqlStatement(my_stmt);
     binding_stmt->Wrap(info.Holder());
 
-    info.GetReturnValue().Set(info.Holder());
+    return info.GetReturnValue().Set(info.Holder());
 }
 
 /** read-only
@@ -131,7 +131,7 @@ NAN_GETTER(MysqlStatement::ParamCountGetter) {
     MYSQLSTMT_MUSTBE_INITIALIZED;
     MYSQLSTMT_MUSTBE_PREPARED;
 
-    info.GetReturnValue().Set(Integer::New(isolate,stmt->param_count));
+    return info.GetReturnValue().Set(Integer::New(isolate,stmt->param_count));
 }
 
 /**
@@ -152,10 +152,10 @@ NAN_METHOD(MysqlStatement::AffectedRowsSync) {
     my_ulonglong affected_rows = mysql_stmt_affected_rows(stmt->_stmt);
 
     if (affected_rows == ((my_ulonglong)-1)) {
-        info.GetReturnValue().Set(Integer::New(isolate,-1));
+        return info.GetReturnValue().Set(Integer::New(isolate,-1));
     }
 
-    info.GetReturnValue().Set(Integer::New(isolate,affected_rows));
+    return info.GetReturnValue().Set(Integer::New(isolate,affected_rows));
 }
 
 /**
@@ -185,11 +185,11 @@ NAN_METHOD(MysqlStatement::AttrGetSync) {
 
     switch (attr_key) {
         case STMT_ATTR_UPDATE_MAX_LENGTH:
-            info.GetReturnValue().Set(Boolean::New(isolate,attr_value));
+            return info.GetReturnValue().Set(Boolean::New(isolate,attr_value));
             break;
         case STMT_ATTR_CURSOR_TYPE:
         case STMT_ATTR_PREFETCH_ROWS:
-            info.GetReturnValue().Set(Integer::NewFromUnsigned(isolate,attr_value));
+            return info.GetReturnValue().Set(Integer::NewFromUnsigned(isolate,attr_value));
             break;
         default:
             return Nan::ThrowError("This attribute isn't supported yet");
@@ -239,7 +239,7 @@ NAN_METHOD(MysqlStatement::AttrSetSync) {
         return Nan::ThrowError("This attribute isn't supported by libmysqlclient");
     }
 
-    info.GetReturnValue().Set(True());
+    return info.GetReturnValue().Set(True());
 }
 
 /**
@@ -351,12 +351,12 @@ NAN_METHOD(MysqlStatement::BindParamsSync) {
     }
 
     if (mysql_stmt_bind_param(stmt->_stmt, stmt->binds)) {
-      info.GetReturnValue().Set(False());
+      return info.GetReturnValue().Set(False());
     }
 
     stmt->state = STMT_BINDED_PARAMS;
 
-    info.GetReturnValue().Set(True());
+    return info.GetReturnValue().Set(True());
 }
 
 /**
@@ -384,7 +384,7 @@ NAN_METHOD(MysqlStatement::BindResultSync) {
 
     meta_result = mysql_stmt_result_metadata(stmt->_stmt);
     if (meta_result == NULL) {
-        info.GetReturnValue().Set(False());
+        return info.GetReturnValue().Set(False());
     }
 
     field_count = mysql_stmt_field_count(stmt->_stmt);
@@ -465,13 +465,13 @@ NAN_METHOD(MysqlStatement::BindResultSync) {
 
     if (mysql_stmt_bind_result(stmt->_stmt, bind)) {
         FreeMysqlBinds(bind, field_count, false);
-        info.GetReturnValue().Set(False());
+        return info.GetReturnValue().Set(False());
     }
 
     stmt->result_binds = bind;
     stmt->state = STMT_BINDED_RESULT;
 
-    info.GetReturnValue().Set(True());
+    return info.GetReturnValue().Set(True());
 }
 
 
@@ -488,13 +488,13 @@ NAN_METHOD(MysqlStatement::CloseSync) {
     MYSQLSTMT_MUSTBE_INITIALIZED;
 
     if (mysql_stmt_close(stmt->_stmt)) {
-        info.GetReturnValue().Set(False());
+        return info.GetReturnValue().Set(False());
     }
 
     stmt->state = STMT_CLOSED;
     stmt->_stmt = NULL;
 
-    info.GetReturnValue().Set(True());
+    return info.GetReturnValue().Set(True());
 }
 
 /*! todo: finish
@@ -519,7 +519,7 @@ NAN_METHOD(MysqlStatement::DataSeekSync) {
     mysql_stmt_data_seek(stmt->_stmt, offset_uint);
 
     //return Nan::Undefined();
-    info.GetReturnValue().Set(Nan::Undefined());
+    return info.GetReturnValue().Set(Nan::Undefined());
 }
 
 /*! todo: finish
@@ -536,7 +536,7 @@ NAN_METHOD(MysqlStatement::ErrnoSync) {
 
     MYSQLSTMT_MUSTBE_INITIALIZED;
 
-    info.GetReturnValue().Set(Integer::New(isolate,mysql_stmt_errno(stmt->_stmt)));
+    return info.GetReturnValue().Set(Integer::New(isolate,mysql_stmt_errno(stmt->_stmt)));
 }
 
 /*! todo: finish
@@ -555,7 +555,7 @@ NAN_METHOD(MysqlStatement::ErrorSync) {
 
     const char *error = mysql_stmt_error(stmt->_stmt);
 
-    info.GetReturnValue().Set(V8STR(error,isolate));
+    return info.GetReturnValue().Set(V8STR(error,isolate));
 }
 
 /*! todo: finish
@@ -620,7 +620,7 @@ NAN_METHOD(MysqlStatement::Execute) {
     _req->data = execute_req;
     uv_queue_work(uv_default_loop(), _req, EIO_Execute, (uv_after_work_cb)EIO_After_Execute);
 
-    info.GetReturnValue().Set(Nan::Undefined());
+    return info.GetReturnValue().Set(Nan::Undefined());
 }
 
 /*! todo: finish
@@ -636,11 +636,11 @@ NAN_METHOD(MysqlStatement::ExecuteSync) {
     MYSQLSTMT_MUSTBE_PREPARED;
 
     if (mysql_stmt_execute(stmt->_stmt)) {
-        info.GetReturnValue().Set(False());
+        return info.GetReturnValue().Set(False());
     }
 
     stmt->state = STMT_EXECUTED;
-    info.GetReturnValue().Set(True());
+    return info.GetReturnValue().Set(True());
 }
 
 void MysqlStatement::EIO_After_FetchAll(uv_work_t* req) {
@@ -769,7 +769,7 @@ NAN_METHOD(MysqlStatement::FetchAll) {
     _req->data = fetchAll_req;
     uv_queue_work(uv_default_loop(), _req, EIO_FetchAll, (uv_after_work_cb)EIO_After_FetchAll);
 
-   info.GetReturnValue().Set(Nan::Undefined());
+   return info.GetReturnValue().Set(Nan::Undefined());
 }
 
 /*! todo: finish
@@ -802,7 +802,7 @@ NAN_METHOD(MysqlStatement::FetchAllSync) {
     // Get meta data for binding buffers
     meta = mysql_stmt_result_metadata(stmt->_stmt);
     if (meta == NULL) {
-        info.GetReturnValue().Set(Null());
+        return info.GetReturnValue().Set(Null());
     }
 
     fields = meta->fields;
@@ -851,7 +851,7 @@ NAN_METHOD(MysqlStatement::FetchAllSync) {
     if (error && error != MYSQL_NO_DATA) {
         return Nan::ThrowError(mysql_stmt_error(stmt->_stmt));
     } else {
-        info.GetReturnValue().Set(js_result);
+        return info.GetReturnValue().Set(js_result);
     }
 }
 
@@ -971,7 +971,7 @@ NAN_METHOD(MysqlStatement::Fetch) {
     _req->data = fetch_req;
     uv_queue_work(uv_default_loop(), _req, EIO_Fetch, (uv_after_work_cb)EIO_After_Fetch);
 
-   info.GetReturnValue().Set(Nan::Undefined());
+   return info.GetReturnValue().Set(Nan::Undefined());
 }
 
 /*! todo: finish
@@ -1002,13 +1002,13 @@ NAN_METHOD(MysqlStatement::FetchSync) {
     // Get meta data for binding buffers
     meta = mysql_stmt_result_metadata(stmt->_stmt);
     if (meta == NULL) {
-        info.GetReturnValue().Set(Null());
+        return info.GetReturnValue().Set(Null());
     }
 
     fields = meta->fields;
 
     if (!mysql_stmt_num_rows(stmt->_stmt)) {
-        info.GetReturnValue().Set(Null());
+        return info.GetReturnValue().Set(Null());
     }
 
     error = mysql_stmt_fetch(stmt->_stmt);
@@ -1047,7 +1047,7 @@ NAN_METHOD(MysqlStatement::FetchSync) {
     if (error) {
         return Nan::ThrowError(mysql_stmt_error(stmt->_stmt));
     } else {
-        info.GetReturnValue().Set(js_result_row);
+        return info.GetReturnValue().Set(js_result_row);
     }
 }
 
@@ -1065,7 +1065,7 @@ NAN_METHOD(MysqlStatement::FieldCountSync) {
 
     MYSQLSTMT_MUSTBE_PREPARED;
 
-    info.GetReturnValue().Set(Integer::New(isolate,mysql_stmt_field_count(stmt->_stmt)));
+    return info.GetReturnValue().Set(Integer::New(isolate,mysql_stmt_field_count(stmt->_stmt)));
 }
 
 /*! todo: finish
@@ -1080,7 +1080,7 @@ NAN_METHOD(MysqlStatement::FreeResultSync) {
 
     MYSQLSTMT_MUSTBE_EXECUTED;
 
-    info.GetReturnValue().Set(!mysql_stmt_free_result(stmt->_stmt) ? True() : False());
+    return info.GetReturnValue().Set(!mysql_stmt_free_result(stmt->_stmt) ? True() : False());
 }
 
 /*! todo: finish
@@ -1290,7 +1290,7 @@ NAN_METHOD(MysqlStatement::LastInsertIdSync) {
 
     MYSQLSTMT_MUSTBE_EXECUTED;
 
-    info.GetReturnValue().Set(Integer::New(isolate,mysql_stmt_insert_id(stmt->_stmt)));
+    return info.GetReturnValue().Set(Integer::New(isolate,mysql_stmt_insert_id(stmt->_stmt)));
 }
 
 /*! todo: finish
@@ -1307,7 +1307,7 @@ NAN_METHOD(MysqlStatement::NextResultSync) {
 
     MYSQLSTMT_MUSTBE_EXECUTED;
 
-    info.GetReturnValue().Set(Integer::New(isolate,mysql_stmt_next_result(stmt->_stmt)));
+    return info.GetReturnValue().Set(Integer::New(isolate,mysql_stmt_next_result(stmt->_stmt)));
 }
 
 /*! todo: finish
@@ -1324,7 +1324,7 @@ NAN_METHOD(MysqlStatement::NumRowsSync) {
 
     MYSQLSTMT_MUSTBE_STORED;  // TODO(Sannis): Or all result already fetched!
 
-    info.GetReturnValue().Set(Integer::New(isolate,mysql_stmt_num_rows(stmt->_stmt)));
+    return info.GetReturnValue().Set(Integer::New(isolate,mysql_stmt_num_rows(stmt->_stmt)));
 }
 
 /*! todo: finish
@@ -1347,7 +1347,7 @@ NAN_METHOD(MysqlStatement::PrepareSync) {
     unsigned long int query_len = info[0]->ToString()->Utf8Length();
 
     if (mysql_stmt_prepare(stmt->_stmt, *query, query_len)) {
-        info.GetReturnValue().Set(False());
+        return info.GetReturnValue().Set(False());
     }
 
     if (stmt->binds) {
@@ -1365,7 +1365,7 @@ NAN_METHOD(MysqlStatement::PrepareSync) {
 
     stmt->state = STMT_PREPARED;
 
-    info.GetReturnValue().Set(True());
+    return info.GetReturnValue().Set(True());
 }
 
 /*! todo: finish
@@ -1381,11 +1381,11 @@ NAN_METHOD(MysqlStatement::ResetSync) {
     MYSQLSTMT_MUSTBE_PREPARED;
 
     if (mysql_stmt_reset(stmt->_stmt)) {
-        info.GetReturnValue().Set(False());
+        return info.GetReturnValue().Set(False());
     }
 
     stmt->state = STMT_INITIALIZED;
-    info.GetReturnValue().Set(True());
+    return info.GetReturnValue().Set(True());
 }
 
 /*! todo: finish
@@ -1403,12 +1403,12 @@ NAN_METHOD(MysqlStatement::ResultMetadataSync) {
     MYSQL_RES *my_result = mysql_stmt_result_metadata(stmt->_stmt);
 
     if (!my_result) {
-        info.GetReturnValue().Set(False());
+        return info.GetReturnValue().Set(False());
     }
 
     Local<Object> local_js_result = MysqlResult::NewInstance(stmt->_stmt->mysql, my_result, mysql_stmt_field_count(stmt->_stmt));
 
-    info.GetReturnValue().Set(local_js_result);
+    return info.GetReturnValue().Set(local_js_result);
 }
 
 /*! todo: finish
@@ -1430,10 +1430,10 @@ NAN_METHOD(MysqlStatement::SendLongDataSync) {
 
     if (mysql_stmt_send_long_data(stmt->_stmt,
                                   parameter_number, *data, data.length())) {
-        info.GetReturnValue().Set(False());
+        return info.GetReturnValue().Set(False());
     }
 
-    info.GetReturnValue().Set(True());
+    return info.GetReturnValue().Set(True());
 }
 
 /*! todo: finish
@@ -1450,7 +1450,7 @@ NAN_METHOD(MysqlStatement::SqlStateSync) {
 
     MYSQLSTMT_MUSTBE_INITIALIZED;
 
-    info.GetReturnValue().Set(V8STR(mysql_stmt_sqlstate(stmt->_stmt),isolate));
+    return info.GetReturnValue().Set(V8STR(mysql_stmt_sqlstate(stmt->_stmt),isolate));
 }
 
 /*! todo: finish
@@ -1512,7 +1512,7 @@ NAN_METHOD(MysqlStatement::StoreResult) {
     _req->data = store_req;
     uv_queue_work(uv_default_loop(), _req, EIO_StoreResult, (uv_after_work_cb)EIO_After_StoreResult);
 
-   info.GetReturnValue().Set(Nan::Undefined());
+   return info.GetReturnValue().Set(Nan::Undefined());
 }
 
 /*! todo: finish
@@ -1529,10 +1529,10 @@ NAN_METHOD(MysqlStatement::StoreResultSync) {
     MYSQLSTMT_MUSTBE_EXECUTED;
 
     if (mysql_stmt_store_result(stmt->_stmt) != 0) {
-        info.GetReturnValue().Set(False());
+        return info.GetReturnValue().Set(False());
     }
 
     stmt->state = STMT_STORED_RESULT;
 
-    info.GetReturnValue().Set(True());
+    return info.GetReturnValue().Set(True());
 }


### PR DESCRIPTION
The nan update branch seems a bit messy, but from what I can gather some tool was used to replace all occurances of `NanReturnValue()` with `info.GetReturnValue().Set()`. The problem with this is that the `NanReturnValue()` macro in nan 1 actually returned from the c function, while the replacement doesn't.

In a lot of cases this library did something like this:
```
if (condition) {
   NanReturnValue(something);
}
NanReturnValue(something_else);
```

Which was replaced by this:
```
if (condition) {
  info.GetReturnValue().Set(something);
}
info.GetReturnValue().Set(something_else);
```

So the JS return value is _always_ set to `something_else` before returning from the c function.

The solution in this branch is not ideal, but seems to work.
